### PR TITLE
feat: drag & drop řazení úkolů

### DIFF
--- a/migrations/002_add_position.sql
+++ b/migrations/002_add_position.sql
@@ -1,0 +1,10 @@
+-- Přidání sloupce position pro řazení úkolů drag & drop
+-- Spusť v Supabase SQL Editoru (DEV projekt)
+
+ALTER TABLE todos ADD COLUMN position integer NOT NULL DEFAULT 0;
+
+-- Existující řádky dostanou pořadí chronologicky podle created_at v rámci dne
+UPDATE todos SET position = sub.rn FROM (
+  SELECT id, ROW_NUMBER() OVER (PARTITION BY date ORDER BY created_at) - 1 AS rn
+  FROM todos
+) sub WHERE todos.id = sub.id;

--- a/migrations/003_reorder_rpc.sql
+++ b/migrations/003_reorder_rpc.sql
@@ -1,0 +1,14 @@
+-- RPC funkce pro atomické přeřazení úkolů
+-- Spusť v Supabase SQL Editoru (DEV projekt)
+
+CREATE OR REPLACE FUNCTION reorder_todos(todo_ids int[], new_positions int[])
+RETURNS void AS $$
+BEGIN
+  IF array_length(todo_ids, 1) != array_length(new_positions, 1) THEN
+    RAISE EXCEPTION 'todo_ids and new_positions must have the same length';
+  END IF;
+  FOR i IN 1..array_length(todo_ids, 1) LOOP
+    UPDATE todos SET position = new_positions[i] WHERE id = todo_ids[i];
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase";
 
 type Todo = {
@@ -8,6 +8,7 @@ type Todo = {
   title: string;
   done: boolean;
   date: string;
+  position: number;
   created_at: string;
 };
 
@@ -33,6 +34,20 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Drag & drop state
+  const [draggedId, setDraggedId] = useState<number | null>(null);
+  const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null);
+
+  // Touch drag state
+  const touchState = useRef<{
+    id: number;
+    startY: number;
+    currentY: number;
+    el: HTMLElement | null;
+    clone: HTMLElement | null;
+  } | null>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
   const isToday = currentDate === formatDate(new Date());
 
   const fetchTodos = useCallback(async () => {
@@ -42,7 +57,7 @@ export default function Home() {
       .from("todos")
       .select("*")
       .eq("date", currentDate)
-      .order("created_at", { ascending: true });
+      .order("position", { ascending: true });
     if (error) {
       setError("Nepodařilo se načíst úkoly.");
     } else {
@@ -58,10 +73,153 @@ export default function Home() {
   async function addTodo(e: React.FormEvent) {
     e.preventDefault();
     if (!newTitle.trim()) return;
-    const { error } = await supabase.from("todos").insert({ title: newTitle.trim(), date: currentDate });
+    // Spočítej max position pro daný den
+    const maxPos = todos.length > 0 ? Math.max(...todos.map((t) => t.position)) : -1;
+    const { error } = await supabase
+      .from("todos")
+      .insert({ title: newTitle.trim(), date: currentDate, position: maxPos + 1 });
     if (error) { setError("Nepodařilo se přidat úkol."); return; }
     setNewTitle("");
     fetchTodos();
+  }
+
+  // Persist nové pořadí do DB — atomická transakce přes RPC
+  async function updatePositions(reordered: Todo[]) {
+    const todo_ids = reordered.map((t) => t.id);
+    const new_positions = reordered.map((_, i) => i);
+    const { error } = await supabase.rpc("reorder_todos", { todo_ids, new_positions });
+    if (error) {
+      setError("Nepodařilo se uložit pořadí.");
+      fetchTodos();
+    }
+  }
+
+  // Přesuň todo z fromIndex na toIndex
+  function reorderTodos(fromIndex: number, toIndex: number) {
+    if (fromIndex === toIndex) return;
+    const reordered = [...todos];
+    const [moved] = reordered.splice(fromIndex, 1);
+    reordered.splice(toIndex, 0, moved);
+    setTodos(reordered);
+    updatePositions(reordered);
+  }
+
+  // --- Desktop drag & drop handlery ---
+  function handleDragStart(e: React.DragEvent, todoId: number) {
+    setDraggedId(todoId);
+    e.dataTransfer.effectAllowed = "move";
+    // Průhledný drag image
+    if (e.currentTarget instanceof HTMLElement) {
+      e.dataTransfer.setDragImage(e.currentTarget, 20, 20);
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent, index: number) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDropTargetIndex(index);
+  }
+
+  function handleDrop(e: React.DragEvent, toIndex: number) {
+    e.preventDefault();
+    if (draggedId == null) return;
+    const fromIndex = todos.findIndex((t) => t.id === draggedId);
+    reorderTodos(fromIndex, toIndex);
+    setDraggedId(null);
+    setDropTargetIndex(null);
+  }
+
+  function handleDragEnd() {
+    setDraggedId(null);
+    setDropTargetIndex(null);
+  }
+
+  // --- Touch drag handlery pro mobil ---
+  function handleTouchStart(e: React.TouchEvent, todoId: number) {
+    const touch = e.touches[0];
+    // Najdi rodičovský <li> pro klon celého řádku
+    const target = (e.currentTarget as HTMLElement).closest("li") as HTMLElement;
+    if (!target) return;
+    // Vytvoř vizuální klon
+    const clone = target.cloneNode(true) as HTMLElement;
+    clone.style.position = "fixed";
+    clone.style.left = `${target.getBoundingClientRect().left}px`;
+    clone.style.top = `${touch.clientY - 20}px`;
+    clone.style.width = `${target.offsetWidth}px`;
+    clone.style.opacity = "0.85";
+    clone.style.pointerEvents = "none";
+    clone.style.zIndex = "1000";
+    clone.style.boxShadow = "0 4px 12px rgba(0,0,0,0.15)";
+    clone.style.borderRadius = "0.5rem";
+    document.body.appendChild(clone);
+
+    touchState.current = {
+      id: todoId,
+      startY: touch.clientY,
+      currentY: touch.clientY,
+      el: target,
+      clone,
+    };
+    target.style.opacity = "0.3";
+  }
+
+  function handleTouchMove(e: React.TouchEvent) {
+    if (!touchState.current || !listRef.current) return;
+    const touch = e.touches[0];
+    touchState.current.currentY = touch.clientY;
+
+    // Posuň klon
+    if (touchState.current.clone) {
+      touchState.current.clone.style.top = `${touch.clientY - 20}px`;
+    }
+
+    // Zjisti nad kterým prvkem jsme
+    const items = listRef.current.querySelectorAll("[data-todo-index]");
+    let newDropIndex: number | null = null;
+    items.forEach((item) => {
+      const rect = item.getBoundingClientRect();
+      const midY = rect.top + rect.height / 2;
+      if (touch.clientY > rect.top && touch.clientY < rect.bottom) {
+        const idx = Number(item.getAttribute("data-todo-index"));
+        newDropIndex = touch.clientY < midY ? idx : idx + 1;
+      }
+    });
+
+    // Pokud jsme pod posledním prvkem
+    if (newDropIndex === null && items.length > 0) {
+      const lastRect = items[items.length - 1].getBoundingClientRect();
+      if (touch.clientY > lastRect.bottom) {
+        newDropIndex = todos.length;
+      }
+    }
+
+    setDropTargetIndex(newDropIndex);
+  }
+
+  function handleTouchEnd() {
+    if (!touchState.current) return;
+    const { id, el, clone } = touchState.current;
+
+    // Odstraň klon
+    if (clone && clone.parentNode) {
+      clone.parentNode.removeChild(clone);
+    }
+    // Obnov opacity
+    if (el) {
+      el.style.opacity = "1";
+    }
+
+    if (dropTargetIndex != null) {
+      const fromIndex = todos.findIndex((t) => t.id === id);
+      let toIndex = dropTargetIndex;
+      // Korekce indexu pokud posouváme dolů
+      if (toIndex > fromIndex) toIndex--;
+      reorderTodos(fromIndex, toIndex);
+    }
+
+    touchState.current = null;
+    setDraggedId(null);
+    setDropTargetIndex(null);
   }
 
   async function toggleTodo(id: number, done: boolean) {
@@ -153,12 +311,44 @@ export default function Home() {
           </p>
         ) : (
           <>
-            <ul className="space-y-2">
-              {todos.map((todo) => (
+            <ul ref={listRef} className="space-y-2">
+              {todos.map((todo, index) => (
                 <li
                   key={todo.id}
-                  className="flex items-center gap-3 rounded-lg bg-white p-3 shadow-sm dark:bg-gray-900"
+                  data-todo-index={index}
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, todo.id)}
+                  onDragOver={(e) => handleDragOver(e, index)}
+                  onDrop={(e) => handleDrop(e, index)}
+                  onDragEnd={handleDragEnd}
+                  className={`flex items-center gap-2 rounded-lg bg-white p-3 shadow-sm dark:bg-gray-900 transition-opacity ${
+                    draggedId === todo.id ? "opacity-30" : ""
+                  } ${
+                    dropTargetIndex === index && draggedId !== todo.id
+                      ? "border-t-2 border-blue-500"
+                      : "border-t-2 border-transparent"
+                  }`}
                 >
+                  {/* Drag handle */}
+                  <button
+                    type="button"
+                    aria-label="Změnit pořadí"
+                    tabIndex={0}
+                    onTouchStart={(e) => handleTouchStart(e, todo.id)}
+                    onTouchMove={(e) => handleTouchMove(e)}
+                    onTouchEnd={handleTouchEnd}
+                    className="shrink-0 cursor-grab touch-none select-none border-0 bg-transparent p-0 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                    title="Přetáhni pro změnu pořadí"
+                  >
+                    <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+                      <circle cx="5" cy="3" r="1.2" />
+                      <circle cx="11" cy="3" r="1.2" />
+                      <circle cx="5" cy="8" r="1.2" />
+                      <circle cx="11" cy="8" r="1.2" />
+                      <circle cx="5" cy="13" r="1.2" />
+                      <circle cx="11" cy="13" r="1.2" />
+                    </svg>
+                  </button>
                   <button
                     onClick={() => toggleTodo(todo.id, todo.done)}
                     className={`flex h-5 w-5 shrink-0 items-center justify-center rounded border ${


### PR DESCRIPTION
## Summary
- Přidán sloupec `position` do tabulky todos + migrace s ROW_NUMBER() pro existující data
- Drag & drop přeřazení úkolů — desktop (native HTML DnD) + mobil (touch events na handle)
- Atomický batch update pozic přes Supabase RPC funkci `reorder_todos`
- Drag handle s grip ikonou, ARIA atributy pro přístupnost

Fixes #4

## Migrace k spuštění
1. `migrations/002_add_position.sql` — přidá sloupec position
2. `migrations/003_reorder_rpc.sql` — RPC funkce pro přeřazení

## Test plan
- [x] Spustit migrace 002 + 003 v DEV Supabase projektu
- [x] Přidat pár úkolů, ověřit že se řadí podle position
- [ ] Desktop: přetáhnout úkol myší, ověřit nové pořadí po refreshi
- [ ] Mobil: přetáhnout přes grip handle, ověřit že scroll funguje mimo handle
- [ ] Smazat úkol, přidat nový — ověřit že position je na konci